### PR TITLE
Update `transaction_hash` in Dex Ag / NFT

### DIFF
--- a/schemas/dex-aggregator/SCHEMA.md
+++ b/schemas/dex-aggregator/SCHEMA.md
@@ -52,7 +52,7 @@ List of trades executed on the protocol.
 | timestamp                | The timestamp of the trade.                               | number |
 | chain_id                 | The standard id of the chain this trade belongs to.       | number |
 | block_number             | The block number in which the trade occurred.             | number |
-| transaction_id           | The transaction id associated with this trade.            | string |
+| transaction_hash         | The transaction hash associated with this trade.          | string |
 | fees                     | The amount of fees from this trade (ie, the revenue generated from executing this trade). | number |
 | fees_usd                 | The fees for this trade in USD.                           | number |
 | slippage                 | (Optional) The slippage of the given trade, as a percentage (ie, 1.3% slippage is 0.013). | number |

--- a/schemas/dex-aggregator/schema.json
+++ b/schemas/dex-aggregator/schema.json
@@ -117,8 +117,8 @@
                     "description": "The block number in which the trade occurred.",
                     "type": "number"
                 },
-                "transaction_id": {
-                    "description": "The transaction id associated with this trade.",
+                "transaction_hash": {
+                    "description": "The transaction hash associated with this trade.",
                     "type": "string"
                 },
                 "fees": {

--- a/schemas/nft/SCHEMA.md
+++ b/schemas/nft/SCHEMA.md
@@ -13,7 +13,7 @@ List of NFT transfers.
 | timestamp                | The timestamp of the transfer.                            | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the transfer.                         | number |
-| transaction_id           | The transaction id of the transfer.                       | string |
+| transaction_hash         | The transaction hash of the transfer.                     | string |
 | nft_collection_address   | The contract address of the NFT collection.               | string |
 | nft_id                   | The unique identifier of the NFT.                         | string |
 | sender_address           | The address of the sender of the NFT.                     | string |

--- a/schemas/nft/schema.json
+++ b/schemas/nft/schema.json
@@ -21,8 +21,8 @@
                     "description": "The block number of the transfer.",
                     "type": "number"
                 },
-                "transaction_id": {
-                    "description": "The transaction id of the transfer.",
+                "transaction_hash": {
+                    "description": "The transaction hash of the transfer.",
                     "type": "string"
                 },
                 "nft_collection_address": {


### PR DESCRIPTION
We want to adhere to the standard of `transaction_hash` and not `transaction_id`