### PR TITLE
Add Protocol Categories and Unique Keys

### DIFF
--- a/schemas/bridge/SCHEMA.md
+++ b/schemas/bridge/SCHEMA.md
@@ -38,7 +38,7 @@ List of liquidity providers in pool-based bridge protocols.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | pool_address             | The address of the pool.                                  | string |
 | lp_address               | The address of the liquidity provider.                    | string |
 | token_address            | The contract address of the token supplied.               | string |
@@ -55,7 +55,7 @@ User level snapshot of accounts that have used the bridge (applicable to pool an
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | pool_address             | (Optional, only applicable to pool-based) The contract address of the pool. | string |
 | user_address             | The address of the user this snapshot activity is based on. | string |
 | amount_in_usd            | The amount of tokens received on this network by the user in USD during the given snapshot. | number |
@@ -70,7 +70,7 @@ Pool level snapshots for pool and mint based bridges.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | pool_address             | The contract address of the pool.                         | string |
 | token_address            | The contract address of the token being bridged or pooled. | string |
 | token_index              | (Optional, only applicable to pool-based) The index of the pooled token in the smart contract. | number |
@@ -109,7 +109,7 @@ List of makers in intent-based bridge protocols.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | user_address             | The address of the maker.                                 | string |
 | token_address            | The smart contract address of the token being supplied by the maker. | string |
 | token_in_amount          | The amount of the token received, decimal normalized.     | number |
@@ -126,7 +126,7 @@ List of takers in intent-based bridge protocols.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | user_address             | The address of the taker.                                 | string |
 | token_address            | The smart contract address of the token.                  | string |
 | volume_amount            | The amount of volume bridged from the source chain, decimal normalized. | number |
@@ -140,7 +140,7 @@ Snapshot of token level data.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | token_address            | he contract address of the token.                         | string |
 | token_amount             | The amount of the token held in the pool, decimal normalized (for pool-based bridges). | number |
 | token_amount_usd         | The amount held in USD.                                   | number |

--- a/schemas/bridge/SCHEMA.md
+++ b/schemas/bridge/SCHEMA.md
@@ -38,6 +38,7 @@ List of liquidity providers in pool-based bridge protocols.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | pool_address             | The address of the pool.                                  | string |
 | lp_address               | The address of the liquidity provider.                    | string |
 | token_address            | The contract address of the token supplied.               | string |
@@ -54,6 +55,7 @@ User level snapshot of accounts that have used the bridge (applicable to pool an
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | pool_address             | (Optional, only applicable to pool-based) The contract address of the pool. | string |
 | user_address             | The address of the user this snapshot activity is based on. | string |
 | amount_in_usd            | The amount of tokens received on this network by the user in USD during the given snapshot. | number |
@@ -68,6 +70,7 @@ Pool level snapshots for pool and mint based bridges.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | pool_address             | The contract address of the pool.                         | string |
 | token_address            | The contract address of the token being bridged or pooled. | string |
 | token_index              | (Optional, only applicable to pool-based) The index of the pooled token in the smart contract. | number |
@@ -106,6 +109,7 @@ List of makers in intent-based bridge protocols.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | user_address             | The address of the maker.                                 | string |
 | token_address            | The smart contract address of the token being supplied by the maker. | string |
 | token_in_amount          | The amount of the token received, decimal normalized.     | number |
@@ -122,6 +126,7 @@ List of takers in intent-based bridge protocols.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | user_address             | The address of the taker.                                 | string |
 | token_address            | The smart contract address of the token.                  | string |
 | volume_amount            | The amount of volume bridged from the source chain, decimal normalized. | number |
@@ -135,6 +140,7 @@ Snapshot of token level data.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | token_address            | he contract address of the token.                         | string |
 | token_amount             | The amount of the token held in the pool, decimal normalized (for pool-based bridges). | number |
 | token_amount_usd         | The amount held in USD.                                   | number |

--- a/schemas/bridge/schema.json
+++ b/schemas/bridge/schema.json
@@ -1,6 +1,7 @@
 {
   "schema": "Bridge",
   "description": "Standard table definitions for bridge protocols, including pool-based, mint-based, and intent-based bridges.",
+  "protocolCategory": ["Bridge (Pool-Based)", "Bridge (Intent-Based)", "Bridge (Mint-Based)"],
   "version": "1.0.0-alpha",
   "tables": [
     {

--- a/schemas/bridge/schema.json
+++ b/schemas/bridge/schema.json
@@ -8,6 +8,7 @@
       "label": "Tokens",
       "tableName": "bridge_intent_tokens",
       "aggregation": "none",
+      "uniqueKey": ["token_address"],
       "description": "List of tokens in bridge protocols.",
       "properties": {
         "token_address": {
@@ -32,6 +33,7 @@
       "label": "Pools",
       "tableName": "bridge_pools",
       "aggregation": "none",
+      "uniqueKey": ["pool_address", "token_index"],
       "description": "List of pools in bridge protocols (applicable for pool and mint based bridges).",
       "properties": {
         "creation_timestamp": {
@@ -76,10 +78,15 @@
       "label": "LP Snapshot",
       "tableName": "bridge_lps",
       "aggregation": "daily",
+      "uniqueKey": ["lp_address", "pool_address", "token_index", "days"],
       "description": "List of liquidity providers in pool-based bridge protocols.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "pool_address": {
@@ -120,10 +127,15 @@
       "label": "User Snapshot",
       "tableName": "bridge_bridgers",
       "aggregation": "daily",
+      "uniqueKey": ["user_address", "pool_address", "days"],
       "description": "User level snapshot of accounts that have used the bridge (applicable to pool and intent based bridges).",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "pool_address": {
@@ -156,10 +168,15 @@
       "label": "Pool Snapshot",
       "tableName": "bridge_pool_metrics",
       "aggregation": "daily",
+      "uniqueKey": ["pool_address", "token_index", "days"],
       "description": "Pool level snapshots for pool and mint based bridges.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "pool_address": {
@@ -208,6 +225,7 @@
       "label": "Bridge Transactions",
       "tableName": "bridge_transactions",
       "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "List of bridge transactions.",
       "properties": {
         "timestamp": {
@@ -268,10 +286,15 @@
       "label": "Maker Snapshot",
       "tableName": "bridge_intent_makers",
       "aggregation": "daily",
+      "uniqueKey": ["user_address", "token_address", "days"],
       "description": "List of makers in intent-based bridge protocols.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "user_address": {
@@ -312,10 +335,15 @@
       "label": "Taker Snapshot",
       "tableName": "bridge_intent_takers",
       "aggregation": "daily",
+      "uniqueKey": ["user_address", "token_address", "days"],
       "description": "List of takers in intent-based bridge protocols.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "user_address": {
@@ -344,10 +372,15 @@
       "label": "Token Snapshot",
       "tableName": "bridge_intent_token_metrics",
       "aggregation": "daily",
+      "uniqueKey": ["token_address", "days"],
       "description": "Snapshot of token level data.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "token_address": {

--- a/schemas/bridge/schema.json
+++ b/schemas/bridge/schema.json
@@ -78,16 +78,16 @@
       "label": "LP Snapshot",
       "tableName": "bridge_lps",
       "aggregation": "daily",
-      "uniqueKey": ["lp_address", "pool_address", "token_index", "days"],
+      "uniqueKey": ["lp_address", "pool_address", "token_index", "block_date"],
       "description": "List of liquidity providers in pool-based bridge protocols.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "pool_address": {
           "description": "The address of the pool.",
@@ -127,16 +127,16 @@
       "label": "User Snapshot",
       "tableName": "bridge_bridgers",
       "aggregation": "daily",
-      "uniqueKey": ["user_address", "pool_address", "days"],
+      "uniqueKey": ["user_address", "pool_address", "block_date"],
       "description": "User level snapshot of accounts that have used the bridge (applicable to pool and intent based bridges).",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "pool_address": {
           "description": "(Optional, only applicable to pool-based) The contract address of the pool.",
@@ -168,16 +168,16 @@
       "label": "Pool Snapshot",
       "tableName": "bridge_pool_metrics",
       "aggregation": "daily",
-      "uniqueKey": ["pool_address", "token_index", "days"],
+      "uniqueKey": ["pool_address", "token_index", "block_date"],
       "description": "Pool level snapshots for pool and mint based bridges.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "pool_address": {
           "description": "The contract address of the pool.",
@@ -286,16 +286,16 @@
       "label": "Maker Snapshot",
       "tableName": "bridge_intent_makers",
       "aggregation": "daily",
-      "uniqueKey": ["user_address", "token_address", "days"],
+      "uniqueKey": ["user_address", "token_address", "block_date"],
       "description": "List of makers in intent-based bridge protocols.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "user_address": {
           "description": "The address of the maker.",
@@ -335,16 +335,16 @@
       "label": "Taker Snapshot",
       "tableName": "bridge_intent_takers",
       "aggregation": "daily",
-      "uniqueKey": ["user_address", "token_address", "days"],
+      "uniqueKey": ["user_address", "token_address", "block_date"],
       "description": "List of takers in intent-based bridge protocols.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "user_address": {
           "description": "The address of the taker.",
@@ -372,16 +372,16 @@
       "label": "Token Snapshot",
       "tableName": "bridge_intent_token_metrics",
       "aggregation": "daily",
-      "uniqueKey": ["token_address", "days"],
+      "uniqueKey": ["token_address", "block_date"],
       "description": "Snapshot of token level data.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "token_address": {
           "description": "he contract address of the token.",

--- a/schemas/derivatives/SCHEMA.md
+++ b/schemas/derivatives/SCHEMA.md
@@ -26,6 +26,7 @@ Liquidity providers snapshot (one entry for each token in a pool).
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | Standard chain id.                                        | number |
 | pool_address             | The address of the pool.                                  | string |
 | lp_address               | The address of the liquidity provider.                    | string |
@@ -49,8 +50,10 @@ Snapshot of the pool's metrics.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | Standard chain id.                                        | number |
 | pool_address             | The smart contract address of the pool.                   | string |
+| token_index              | The index of the token in the smart contract (one row for each token in a pool). | number |
 | funding_rate             | The funding rate in this pool at the time of the snapshot, as a percentage. | number |
 | fee_rate                 | he pool's fee rate, as a percentage.                      | number |
 | total_value_locked_usd   | The total value locked in USD.                            | number |

--- a/schemas/derivatives/SCHEMA.md
+++ b/schemas/derivatives/SCHEMA.md
@@ -26,7 +26,7 @@ Liquidity providers snapshot (one entry for each token in a pool).
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | Standard chain id.                                        | number |
 | pool_address             | The address of the pool.                                  | string |
 | lp_address               | The address of the liquidity provider.                    | string |
@@ -50,7 +50,7 @@ Snapshot of the pool's metrics.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | Standard chain id.                                        | number |
 | pool_address             | The smart contract address of the pool.                   | string |
 | token_index              | The index of the token in the smart contract (one row for each token in a pool). | number |

--- a/schemas/derivatives/schema.json
+++ b/schemas/derivatives/schema.json
@@ -49,16 +49,16 @@
       "label": "LP Snapshot",
       "table_name": "lp_snapshot",
       "aggregation": "daily",
-      "uniqueKey": ["lp_address", "pool_address", "token_index", "days"],
+      "uniqueKey": ["lp_address", "pool_address", "token_index", "block_date"],
       "description": "Liquidity providers snapshot (one entry for each token in a pool).",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         }, 
         "chain_id": {
           "description": "Standard chain id.",
@@ -126,16 +126,16 @@
       "label": "Pool Snapshot",
       "table_name": "pool_snapshot",
       "aggregation": "daily",
-      "uniqueKey": ["pool_address", "token_index", "days"],
+      "uniqueKey": ["pool_address", "token_index", "block_date"],
       "description": "Snapshot of the pool's metrics.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         }, 
         "chain_id": {
           "description": "Standard chain id.",

--- a/schemas/derivatives/schema.json
+++ b/schemas/derivatives/schema.json
@@ -1,6 +1,7 @@
 {
   "schema": "Derivatives",
   "description": "OpenBlock Labs standard schema for derivatives protocols (options and perps).",
+  "protocolCategory": ["Derivatives", "Option", "Perpetual"],
   "version": "1.0.0-alpha",
   "tables": [
     {

--- a/schemas/derivatives/schema.json
+++ b/schemas/derivatives/schema.json
@@ -8,6 +8,7 @@
       "label": "Pools",
       "table_name": "derivatives_pools",
       "aggregation": "none",
+      "uniqueKey": ["pool_address", "token_index"],
       "description": "Pools in the protocol (one entry for each token).",
       "properties": {
         "chain_id": {
@@ -47,13 +48,18 @@
     {
       "label": "LP Snapshot",
       "table_name": "lp_snapshot",
-      "aggregation": "none",
+      "aggregation": "daily",
+      "uniqueKey": ["lp_address", "pool_address", "token_index", "days"],
       "description": "Liquidity providers snapshot (one entry for each token in a pool).",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
+        "days": {
+          "description": "The number of days since unix epoch time.",
+          "type": "number"
+        }, 
         "chain_id": {
           "description": "Standard chain id.",
           "type": "number"
@@ -119,13 +125,18 @@
     {
       "label": "Pool Snapshot",
       "table_name": "pool_snapshot",
-      "aggregation": "none",
+      "aggregation": "daily",
+      "uniqueKey": ["pool_address", "token_index", "days"],
       "description": "Snapshot of the pool's metrics.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
+        "days": {
+          "description": "The number of days since unix epoch time.",
+          "type": "number"
+        }, 
         "chain_id": {
           "description": "Standard chain id.",
           "type": "number"
@@ -133,6 +144,10 @@
         "pool_address": {
           "description": "The smart contract address of the pool.",
           "type": "string"
+        },
+        "token_index": {
+          "description": "The index of the token in the smart contract (one row for each token in a pool).",
+          "type": "number"
         },
         "funding_rate": {
           "description": "The funding rate in this pool at the time of the snapshot, as a percentage.",
@@ -163,7 +178,8 @@
     {
       "label": "Trades",
       "table_name": "trades",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Trade data, 1 entry for each close, open, or update of a trade.",
       "properties": {
         "timestamp": {

--- a/schemas/dex-aggregator/SCHEMA.md
+++ b/schemas/dex-aggregator/SCHEMA.md
@@ -23,6 +23,7 @@ Volume, fees, and incentives data at the token level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the record.                              | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | token_address            | The contract address of the token.                        | string |
 | volume_amount            | The volume amount of the token, during the snapshot period, decimal normalized. | number |
@@ -39,6 +40,7 @@ Volume and fees data at the protocol level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the block this snapshot was taken.       | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | volume_usd               | The volume in USD, in the given snapshot period.          | number |
 | fees_usd                 | The fees (ie, total revenue generated in the protocol) collected in USD, during the snapshot period. | number |
@@ -53,6 +55,7 @@ List of trades executed on the protocol.
 | chain_id                 | The standard id of the chain this trade belongs to.       | number |
 | block_number             | The block number in which the trade occurred.             | number |
 | transaction_hash         | The transaction hash associated with this trade.          | string |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | fees                     | The amount of fees from this trade (ie, the revenue generated from executing this trade). | number |
 | fees_usd                 | The fees for this trade in USD.                           | number |
 | slippage                 | (Optional) The slippage of the given trade, as a percentage (ie, 1.3% slippage is 0.013). | number |

--- a/schemas/dex-aggregator/SCHEMA.md
+++ b/schemas/dex-aggregator/SCHEMA.md
@@ -23,7 +23,7 @@ Volume, fees, and incentives data at the token level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the record.                              | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | token_address            | The contract address of the token.                        | string |
 | volume_amount            | The volume amount of the token, during the snapshot period, decimal normalized. | number |
@@ -40,7 +40,7 @@ Volume and fees data at the protocol level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the block this snapshot was taken.       | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | volume_usd               | The volume in USD, in the given snapshot period.          | number |
 | fees_usd                 | The fees (ie, total revenue generated in the protocol) collected in USD, during the snapshot period. | number |

--- a/schemas/dex-aggregator/schema.json
+++ b/schemas/dex-aggregator/schema.json
@@ -8,6 +8,7 @@
             "label": "Tokens",
             "table_name": "dex_agg_tokens",
             "aggregation": "none",
+            "uniqueKey": ["token_address"],
             "description": "List of tokens supported by the protocol.",
             "properties": {
                 "chain_id": {
@@ -36,10 +37,15 @@
             "label": "Token Snapshot",
             "table_name": "dex_agg_token_metrics",
             "aggregation": "daily",
+            "uniqueKey": ["token_address", "days"],
             "description": "Volume, fees, and incentives data at the token level.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the record.",
+                    "type": "number"
+                },
+                "days": {
+                    "description": "The number of days since unix epoch time.",
                     "type": "number"
                 },
                 "chain_id": {
@@ -80,10 +86,15 @@
             "label": "Protocol Snapshot",
             "table_name": "dex_agg_metrics",
             "aggregation": "daily",
+            "uniqueKey": ["days"],
             "description": "Volume and fees data at the protocol level.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the block this snapshot was taken.",
+                    "type": "number"
+                },
+                "days": {
+                    "description": "The number of days since unix epoch time.",
                     "type": "number"
                 },
                 "chain_id": {
@@ -104,6 +115,7 @@
             "label": "Trades",
             "table_name": "dex_agg_trades",
             "aggregation": "transaction",
+            "uniqueKey": ["transaction_hash", "log_index"],
             "description": "List of trades executed on the protocol.",
             "properties": {
                 "timestamp": {
@@ -121,6 +133,10 @@
                 "transaction_hash": {
                     "description": "The transaction hash associated with this trade.",
                     "type": "string"
+                },
+                "log_index": {
+                    "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
+                    "type": "number"
                 },
                 "fees": {
                     "description": "The amount of fees from this trade (ie, the revenue generated from executing this trade).",

--- a/schemas/dex-aggregator/schema.json
+++ b/schemas/dex-aggregator/schema.json
@@ -37,16 +37,16 @@
             "label": "Token Snapshot",
             "table_name": "dex_agg_token_metrics",
             "aggregation": "daily",
-            "uniqueKey": ["token_address", "days"],
+            "uniqueKey": ["token_address", "block_date"],
             "description": "Volume, fees, and incentives data at the token level.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the record.",
                     "type": "number"
                 },
-                "days": {
-                    "description": "The number of days since unix epoch time.",
-                    "type": "number"
+                "block_date": {
+                    "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+                    "type": "date"
                 },
                 "chain_id": {
                     "description": "The standard id of the chain.",
@@ -86,16 +86,16 @@
             "label": "Protocol Snapshot",
             "table_name": "dex_agg_metrics",
             "aggregation": "daily",
-            "uniqueKey": ["days"],
+            "uniqueKey": ["block_date"],
             "description": "Volume and fees data at the protocol level.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the block this snapshot was taken.",
                     "type": "number"
                 },
-                "days": {
-                    "description": "The number of days since unix epoch time.",
-                    "type": "number"
+                "block_date": {
+                    "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+                    "type": "date"
                 },
                 "chain_id": {
                     "description": "The standard id of the chain.",

--- a/schemas/dex-aggregator/schema.json
+++ b/schemas/dex-aggregator/schema.json
@@ -1,6 +1,7 @@
 {
     "schema": "DEX Aggregator",
     "description": "Standard table definitions for DEX aggregators.",
+    "protcolCategory": ["DEX Aggregator", "Trading"],
     "version": "1.0.0-alpha",
     "tables": [
         {

--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -30,6 +30,7 @@ Snapshot of LP positions.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the pool.                         | string |
 | user_address             | The address of the liquidity provider.                    | string |
@@ -46,6 +47,7 @@ Snapshot of pool states.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the LP pool.                      | string |
 | token_index              | The token index in the smart contract.                    | number |
@@ -69,7 +71,7 @@ All trades across different types of DEXs.
 | timestamp                | The timestamp of the transaction.                         | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the trade.                            | number |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | user_address             | The address that initiates the transaction (ie, the transaction signer). | string |
 | taker_address            | The taker, the address that receives the output of the swap (ie, could be the same as user_address unless a proxy contract/router is used). | string |
@@ -91,6 +93,7 @@ Snapshot of user scores.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the record.                              | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the record.                           | number |
 | user_address             | The address of the user.                                  | string |
@@ -107,6 +110,8 @@ Mint events for V2.
 | timestamp                | The timestamp of the record.                              | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the mint.                             | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
+| transaction_hash         | The hash of the transaction.                              | string |
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
 | from_address             | The from address of the event (ie, the from field in a transfer). | string |
 | to_address               | The to address of the event (ie, the to field in a transfer). | string |
@@ -127,7 +132,7 @@ Burn events for V2.
 | timestamp                | The timestamp of the transaction.                         | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the trade.                            | number |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
 | from_address             | The from address of the event (ie, the from field in a transfer). | string |
@@ -149,7 +154,7 @@ Sync events for V2.
 | timestamp                | The timestamp of the transaction.                         | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the trade.                            | number |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | pool_address             | The contract address of the pool.                         | string |
 | token0_address           | The contract address of token0.                           | string |
@@ -166,7 +171,7 @@ Transfer events for V2.
 | timestamp                | The timestamp of the transaction.                         | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the trade.                            | number |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
 | from_address             | The address that sends the LP token.                      | string |
@@ -183,7 +188,7 @@ Events for V3.
 | timestamp                | The timestamp of the transaction.                         | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the trade.                            | number |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
 | from_address             | The from address of the event (ie, the from field in a transfer). | string |
@@ -209,7 +214,7 @@ Transfer events for V3.
 | timestamp                | The timestamp of the transaction.                         | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the trade.                            | number |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
 | from_address             | The from address of the event (ie, the from field in a transfer). | string |

--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -30,7 +30,7 @@ Snapshot of LP positions.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the pool.                         | string |
 | user_address             | The address of the liquidity provider.                    | string |
@@ -47,7 +47,7 @@ Snapshot of pool states.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the LP pool.                      | string |
 | token_index              | The token index in the smart contract.                    | number |
@@ -93,7 +93,7 @@ Snapshot of user scores.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the record.                              | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the record.                           | number |
 | user_address             | The address of the user.                                  | string |

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -1,6 +1,7 @@
 {
   "schema": "DEX",
   "description": "Standard table definitions for dex protocols.",
+  "protocolCategory": ["DEX"],
   "version": "1.0.0",
   "tables": [
     {

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -65,16 +65,16 @@
       "label": "LP Position Snapshot",
       "table_name": "lp_position_snapshot",
       "aggregation": "daily",
-      "uniqueKey": ["user_address", "pool_address", "token_index", "days"],
+      "uniqueKey": ["user_address", "pool_address", "token_index", "block_date"],
       "description": "Snapshot of LP positions.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         }, 
         "chain_id": {
           "description": "The standard id of the chain.",
@@ -114,16 +114,16 @@
       "label": "Pool Snapshot",
       "table_name": "pool_snapshot",
       "aggregation": "daily",
-      "uniqueKey": ["pool_address", "token_index", "days"],
+      "uniqueKey": ["pool_address", "token_index", "block_date"],
       "description": "Snapshot of pool states.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         }, 
         "chain_id": {
           "description": "The standard id of the chain.",
@@ -260,16 +260,16 @@
       "label": "User Score Snapshot",
       "table_name": "user_score_snapshot",
       "aggregation": "daily",
-      "uniqueKey": ["user_address", "pool_address", "days"],
+      "uniqueKey": ["user_address", "pool_address", "block_date"],
       "description": "Snapshot of user scores.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the record.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         }, 
         "chain_id": {
           "description": "The standard id of the chain.",

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -8,6 +8,7 @@
       "label": "Pools",
       "table_name": "dex_pools",
       "aggregation": "none",
+      "uniqueKey": ["pool_address", "token_index"],
       "description": "List of LP pools in this protocol (one entry per token in a pool).",
       "properties": {
         "chain_id": {
@@ -63,13 +64,18 @@
     {
       "label": "LP Position Snapshot",
       "table_name": "lp_position_snapshot",
-      "aggregation": "none",
+      "aggregation": "daily",
+      "uniqueKey": ["user_address", "pool_address", "token_index", "days"],
       "description": "Snapshot of LP positions.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
+        "days": {
+          "description": "The number of days since unix epoch time.",
+          "type": "number"
+        }, 
         "chain_id": {
           "description": "The standard id of the chain.",
           "type": "number"
@@ -107,13 +113,18 @@
     {
       "label": "Pool Snapshot",
       "table_name": "pool_snapshot",
-      "aggregation": "none",
+      "aggregation": "daily",
+      "uniqueKey": ["pool_address", "token_index", "days"],
       "description": "Snapshot of pool states.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
+        "days": {
+          "description": "The number of days since unix epoch time.",
+          "type": "number"
+        }, 
         "chain_id": {
           "description": "The standard id of the chain.",
           "type": "number"
@@ -171,7 +182,8 @@
     {
       "label": "Trades (All DEX Types)",
       "table_name": "dex_trades",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "All trades across different types of DEXs.",
       "properties": {
         "timestamp": {
@@ -187,7 +199,7 @@
           "type": "number"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "transaction_hash": {
@@ -247,13 +259,18 @@
     {
       "label": "User Score Snapshot",
       "table_name": "user_score_snapshot",
-      "aggregation": "none",
+      "aggregation": "daily",
+      "uniqueKey": ["user_address", "pool_address", "days"],
       "description": "Snapshot of user scores.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the record.",
           "type": "number"
         },
+        "days": {
+          "description": "The number of days since unix epoch time.",
+          "type": "number"
+        }, 
         "chain_id": {
           "description": "The standard id of the chain.",
           "type": "number"
@@ -283,7 +300,8 @@
     {
       "label": "V2 Mints",
       "table_name": "v2_mints",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Mint events for V2.",
       "properties": {
         "timestamp": {
@@ -297,6 +315,14 @@
         "block_number": {
           "description": "The block number of the mint.",
           "type": "number"
+        },
+        "log_index": {
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
+          "type": "number"
+        },
+        "transaction_hash": {
+          "description": "The hash of the transaction.",
+          "type": "string"
         },
         "transaction_from_address": {
           "description": "The address that initiates the transaction (ie, the transaction signer).",
@@ -343,7 +369,8 @@
     {
       "label": "V2 Burns",
       "table_name": "v2_burns",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Burn events for V2.",
       "properties": {
         "timestamp": {
@@ -359,7 +386,7 @@
           "type": "number"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "transaction_hash": {
@@ -411,7 +438,8 @@
     {
       "label": "V2 Syncs",
       "table_name": "v2_syncs",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Sync events for V2.",
       "properties": {
         "timestamp": {
@@ -427,7 +455,7 @@
           "type": "number"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "transaction_hash": {
@@ -459,7 +487,8 @@
     {
       "label": "V2 Transfers",
       "table_name": "v2_transfers",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Transfer events for V2.",
       "properties": {
         "timestamp": {
@@ -475,7 +504,7 @@
           "type": "number"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "transaction_hash": {
@@ -507,7 +536,8 @@
     {
       "label": "V3 Events",
       "table_name": "v3_events",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Events for V3.",
       "properties": {
         "timestamp": {
@@ -523,7 +553,7 @@
           "type": "number"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "transaction_hash": {
@@ -591,7 +621,8 @@
     {
       "label": "V3 Transfers",
       "table_name": "v3_transfers",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Transfer events for V3.",
       "properties": {
         "timestamp": {
@@ -607,7 +638,7 @@
           "type": "number"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "transaction_hash": {

--- a/schemas/general/SCHEMA.md
+++ b/schemas/general/SCHEMA.md
@@ -43,7 +43,7 @@ APR and APY data at the pool level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the record.                              | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard chain id.                                    | number |
 | protocol_type            | The type of protocol (ie, Lending, CDP, DEX, Gaming, etc). | string |
 | pool_address             | The smart contract address of the pool.                   | string |
@@ -59,7 +59,7 @@ Protocol level snapshot focused on incentives and users.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard chain id.                                    | number |
 | daily_active_users       | The number of unique daily active users on this protocol. | number |
 | transaction_count        | The number of transactions in this time period.           | number |

--- a/schemas/general/SCHEMA.md
+++ b/schemas/general/SCHEMA.md
@@ -13,7 +13,7 @@ Transactional data on user level incentives claimed data.
 | timestamp                | The timestamp of the claim.                               | number |
 | chain_id                 | The standard chain id.                                    | number |
 | transaction_hash         | The hash of the transaction.                              | string |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | user_address             | The address of the user who claimed the incentives.       | string |
 | claimed_token_address    | The smart contract address of the claimed token.          | string |
 | claimed_token_amount     | The amount of the token claimed, decimal normalized.      | number |
@@ -30,7 +30,7 @@ Schema for airdrop data.
 | user_address             | The address of the user claiming the airdrop.             | string |
 | claim_timestamp          | The timestamp of when the user claimed the airdrop.       | number |
 | transaction_hash         | The hash of the transaction.                              | string |
-| log_index                | The log index of the event recorded.                      | number |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | airdrop_token_address    | The smart contract address of the airdropped token.       | string |
 | airdrop_token_symbol     | The symbol of the token being airdropped.                 | string |
 | token_amount             | The amount of each token airdropped, decimal normalized.  | number |
@@ -43,6 +43,7 @@ APR and APY data at the pool level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the record.                              | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard chain id.                                    | number |
 | protocol_type            | The type of protocol (ie, Lending, CDP, DEX, Gaming, etc). | string |
 | pool_address             | The smart contract address of the pool.                   | string |
@@ -58,6 +59,7 @@ Protocol level snapshot focused on incentives and users.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard chain id.                                    | number |
 | daily_active_users       | The number of unique daily active users on this protocol. | number |
 | transaction_count        | The number of transactions in this time period.           | number |

--- a/schemas/general/schema.json
+++ b/schemas/general/schema.json
@@ -1,6 +1,7 @@
 {
   "schema": "General",
   "description": "Table definitions for the generic schema. These tables can be used for any protocol.",
+  "protocolCategory": ["Bond", "Gaming", "Oracle", "Payment", "Quest", "SocialFi", "Stablecoin", "Wallet"],
   "version": "1.0.0-alpha",
   "tables": [
     {

--- a/schemas/general/schema.json
+++ b/schemas/general/schema.json
@@ -8,6 +8,7 @@
       "label": "Incentive Claim Data",
       "tableName": "user_incentive_claim",
       "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Transactional data on user level incentives claimed data.",
       "properties": {
         "timestamp": {
@@ -23,7 +24,7 @@
           "type": "string"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "user_address": {
@@ -51,7 +52,8 @@
     {
       "label": "Airdrop",
       "tableName": "general_airdrop",
-      "aggregation": "none",
+      "aggregation": "transaction",
+      "uniqueKey": ["transaction_hash", "log_index"],
       "description": "Schema for airdrop data.",
       "properties": {
         "airdrop_timestamp": {
@@ -71,7 +73,7 @@
           "type": "string"
         },
         "log_index": {
-          "description": "The log index of the event recorded.",
+          "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
           "type": "number"
         },
         "airdrop_token_address": {
@@ -96,10 +98,15 @@
       "label": "Pool Snapshot",
       "tableName": "general_pools",
       "aggregation": "daily",
+      "uniqueKey": ["pool_address", "days"],
       "description": "APR and APY data at the pool level.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the record.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "chain_id": {
@@ -136,10 +143,15 @@
       "label": "Protocol Snapshot",
       "tableName": "general_metrics",
       "aggregation": "daily",
+      "uniqueKey": ["days"],
       "description": "Protocol level snapshot focused on incentives and users.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "chain_id": {

--- a/schemas/general/schema.json
+++ b/schemas/general/schema.json
@@ -98,16 +98,16 @@
       "label": "Pool Snapshot",
       "tableName": "general_pools",
       "aggregation": "daily",
-      "uniqueKey": ["pool_address", "days"],
+      "uniqueKey": ["pool_address", "block_date"],
       "description": "APR and APY data at the pool level.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the record.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "chain_id": {
           "description": "The standard chain id.",
@@ -143,16 +143,16 @@
       "label": "Protocol Snapshot",
       "tableName": "general_metrics",
       "aggregation": "daily",
-      "uniqueKey": ["days"],
+      "uniqueKey": ["block_date"],
       "description": "Protocol level snapshot focused on incentives and users.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "chain_id": {
           "description": "The standard chain id.",

--- a/schemas/lending/SCHEMA.md
+++ b/schemas/lending/SCHEMA.md
@@ -27,6 +27,7 @@ Snapshot of user positions in the lending protocol.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the pool.                         | string |
 | underlying_token_address | The contract address of the underlying token.             | string |
@@ -46,6 +47,7 @@ Snapshot of the pool's state in the lending protocol.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the pool.                         | string |
 | underlying_token_address | The contract address of the underlying token.             | string |

--- a/schemas/lending/SCHEMA.md
+++ b/schemas/lending/SCHEMA.md
@@ -27,7 +27,7 @@ Snapshot of user positions in the lending protocol.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the pool.                         | string |
 | underlying_token_address | The contract address of the underlying token.             | string |
@@ -47,7 +47,7 @@ Snapshot of the pool's state in the lending protocol.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard id of the chain.                             | number |
 | pool_address             | The contract address of the pool.                         | string |
 | underlying_token_address | The contract address of the underlying token.             | string |

--- a/schemas/lending/schema.json
+++ b/schemas/lending/schema.json
@@ -53,16 +53,16 @@
             "label": "Position Snapshot",
             "table_name": "lending_position_snapshot",
             "aggregation": "daily",
-            "uniqueKey": ["user_address", "pool_address", "days"],
+            "uniqueKey": ["user_address", "pool_address", "block_date"],
             "description": "Snapshot of user positions in the lending protocol.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the snapshot.",
                     "type": "number"
                 },
-                "days": {
-                    "description": "The number of days since unix epoch time.",
-                    "type": "number"
+                "block_date": {
+                    "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+                    "type": "date"
                     },
                 "chain_id": {
                     "description": "The standard id of the chain.",
@@ -114,16 +114,16 @@
             "label": "Pool Snapshot",
             "table_name": "lending_pool_snapshot",
             "aggregation": "daily",
-            "uniqueKey": ["pool_address", "days"],
+            "uniqueKey": ["pool_address", "block_date"],
             "description": "Snapshot of the pool's state in the lending protocol.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the snapshot.",
                     "type": "number"
                 },
-                "days": {
-                    "description": "The number of days since unix epoch time.",
-                    "type": "number"
+                "block_date": {
+                    "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+                    "type": "date"
                 },  
                 "chain_id": {
                     "description": "The standard id of the chain.",

--- a/schemas/lending/schema.json
+++ b/schemas/lending/schema.json
@@ -1,6 +1,7 @@
 {
     "schema": "Lending / MM / CDP",
     "description": "Standard table definitions for lending protocols.",
+    "protocolCategory": ["CDP", "Lending"],
     "version": "1.0.0",
     "tables": [
         {

--- a/schemas/lending/schema.json
+++ b/schemas/lending/schema.json
@@ -7,6 +7,7 @@
         {
             "label": "Pools",
             "table_name": "lending_pools",
+            "uniqueKey": ["pool_address"],
             "aggregation": "none",
             "description": "List of pools in the lending protocol.",
             "properties": {
@@ -52,12 +53,17 @@
             "label": "Position Snapshot",
             "table_name": "lending_position_snapshot",
             "aggregation": "daily",
+            "uniqueKey": ["user_address", "pool_address", "days"],
             "description": "Snapshot of user positions in the lending protocol.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the snapshot.",
                     "type": "number"
                 },
+                "days": {
+                    "description": "The number of days since unix epoch time.",
+                    "type": "number"
+                    },
                 "chain_id": {
                     "description": "The standard id of the chain.",
                     "type": "number"
@@ -108,12 +114,17 @@
             "label": "Pool Snapshot",
             "table_name": "lending_pool_snapshot",
             "aggregation": "daily",
+            "uniqueKey": ["pool_address", "days"],
             "description": "Snapshot of the pool's state in the lending protocol.",
             "properties": {
                 "timestamp": {
                     "description": "The timestamp of the snapshot.",
                     "type": "number"
                 },
+                "days": {
+                    "description": "The number of days since unix epoch time.",
+                    "type": "number"
+                },  
                 "chain_id": {
                     "description": "The standard id of the chain.",
                     "type": "number"

--- a/schemas/lst/SCHEMA.md
+++ b/schemas/lst/SCHEMA.md
@@ -11,7 +11,7 @@ User level snapshot of holders in this protocol.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | Standard chain ID.                                        | number |
 | token_address            | The contract address of the LST.                          | string |
 | token_symbol             | The symbol of the token.                                  | string |
@@ -26,7 +26,7 @@ Snapshot at the protocol level, including, TVL and fees data.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | Standard chain ID.                                        | number |
 | total_value_locked_usd   | The total value locked in USD (ie, the value of the liquid staking tokens in the protocol). | number |
 | fees_usd                 | The fees collected in USD in the given snapshot period.   | number |

--- a/schemas/lst/SCHEMA.md
+++ b/schemas/lst/SCHEMA.md
@@ -11,6 +11,7 @@ User level snapshot of holders in this protocol.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | Standard chain ID.                                        | number |
 | token_address            | The contract address of the LST.                          | string |
 | token_symbol             | The symbol of the token.                                  | string |
@@ -25,6 +26,7 @@ Snapshot at the protocol level, including, TVL and fees data.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | Standard chain ID.                                        | number |
 | total_value_locked_usd   | The total value locked in USD (ie, the value of the liquid staking tokens in the protocol). | number |
 | fees_usd                 | The fees collected in USD in the given snapshot period.   | number |

--- a/schemas/lst/schema.json
+++ b/schemas/lst/schema.json
@@ -8,16 +8,16 @@
         "label": "Position Snapshot",
         "tableName": "lst_holders",
         "aggregation": "daily",
-        "uniqueKey": ["user_address", "token_address", "days"],
+        "uniqueKey": ["user_address", "token_address", "block_date"],
         "description": "User level snapshot of holders in this protocol.",
         "properties": {
           "timestamp": {
             "description": "The timestamp of the snapshot.",
             "type": "number"
           },
-          "days": {
-            "description": "The number of days since unix epoch time.",
-            "type": "number"
+          "block_date": {
+            "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+            "type": "date"
           },
           "chain_id": {
             "description": "Standard chain ID.",
@@ -49,16 +49,16 @@
         "label": "Protocol Snapshot",
         "tableName": "lst_metrics",
         "aggregation": "daily",
-        "uniqueKey": ["days"],
+        "uniqueKey": ["block_date"],
         "description": "Snapshot at the protocol level, including, TVL and fees data.",
         "properties": {
           "timestamp": {
             "description": "The timestamp of the snapshot.",
             "type": "number"
           },
-          "days": {
-            "description": "The number of days since unix epoch time.",
-            "type": "number"
+          "block_date": {
+            "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+            "type": "date"
           },
           "chain_id": {
             "description": "Standard chain ID.",

--- a/schemas/lst/schema.json
+++ b/schemas/lst/schema.json
@@ -1,6 +1,7 @@
 {
     "schema": "Liquid Staking Tokens (LSTs)",
     "description": "Standard table definitions for LSTs (liquid staking tokens)",
+    "protocolCategory": ["LRT", "LST"],
     "version": "1.0.0-alpha",
     "tables": [
       {

--- a/schemas/lst/schema.json
+++ b/schemas/lst/schema.json
@@ -8,10 +8,15 @@
         "label": "Position Snapshot",
         "tableName": "lst_holders",
         "aggregation": "daily",
+        "uniqueKey": ["user_address", "token_address", "days"],
         "description": "User level snapshot of holders in this protocol.",
         "properties": {
           "timestamp": {
             "description": "The timestamp of the snapshot.",
+            "type": "number"
+          },
+          "days": {
+            "description": "The number of days since unix epoch time.",
             "type": "number"
           },
           "chain_id": {
@@ -44,10 +49,15 @@
         "label": "Protocol Snapshot",
         "tableName": "lst_metrics",
         "aggregation": "daily",
+        "uniqueKey": ["days"],
         "description": "Snapshot at the protocol level, including, TVL and fees data.",
         "properties": {
           "timestamp": {
             "description": "The timestamp of the snapshot.",
+            "type": "number"
+          },
+          "days": {
+            "description": "The number of days since unix epoch time.",
             "type": "number"
           },
           "chain_id": {

--- a/schemas/nft/SCHEMA.md
+++ b/schemas/nft/SCHEMA.md
@@ -14,6 +14,7 @@ List of NFT transfers.
 | chain_id                 | The standard id of the chain.                             | number |
 | block_number             | The block number of the transfer.                         | number |
 | transaction_hash         | The transaction hash of the transfer.                     | string |
+| log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | nft_collection_address   | The contract address of the NFT collection.               | string |
 | nft_id                   | The unique identifier of the NFT.                         | string |
 | sender_address           | The address of the sender of the NFT.                     | string |

--- a/schemas/nft/schema.json
+++ b/schemas/nft/schema.json
@@ -1,6 +1,7 @@
 {
     "schema": "NFT",
     "description": "Standard table definitions for NFTs.",
+    "protocolCategory": ["NFT"],
     "version": "1.0.0-alpha",
     "tables": [
         {

--- a/schemas/nft/schema.json
+++ b/schemas/nft/schema.json
@@ -8,6 +8,7 @@
             "label": "NFT Transfers",
             "table_name": "nft_transfers",
             "aggregation": "transaction",
+            "uniqueKey": ["transaction_hash", "log_index"],
             "description": "List of NFT transfers.",
             "properties": {
                 "timestamp": {
@@ -25,6 +26,10 @@
                 "transaction_hash": {
                     "description": "The transaction hash of the transfer.",
                     "type": "string"
+                },
+                "log_index": {
+                    "description": "The event log. For transactions that don't emit event, create arbitrary index starting from 0.",
+                    "type": "number"
                 },
                 "nft_collection_address": {
                     "description": "The contract address of the NFT collection.",

--- a/schemas/yield-aggregator/SCHEMA.md
+++ b/schemas/yield-aggregator/SCHEMA.md
@@ -30,6 +30,7 @@ Snapshot of the pool users.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard chain id.                                    | number |
 | pool_address             | The address of the pool this user has a position in.      | string |
 | user_address             | The address of the user who has a position in the pool.   | string |
@@ -46,6 +47,7 @@ TVL, fees, and incentives data at the pool level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
+| days                     | The number of days since unix epoch time.                 | number |
 | chain_id                 | The standard chain id.                                    | number |
 | underlying_token_address | The contract address of the underlying token or deposited token. | string |
 | underlying_token_index   | The index of the underlying token in the smart contract, default 0. | number |

--- a/schemas/yield-aggregator/SCHEMA.md
+++ b/schemas/yield-aggregator/SCHEMA.md
@@ -30,7 +30,7 @@ Snapshot of the pool users.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard chain id.                                    | number |
 | pool_address             | The address of the pool this user has a position in.      | string |
 | user_address             | The address of the user who has a position in the pool.   | string |
@@ -47,7 +47,7 @@ TVL, fees, and incentives data at the pool level.
 | Property                | Description                                               | Type   |
 |-------------------------|-----------------------------------------------------------|--------|
 | timestamp                | The timestamp of the snapshot.                            | number |
-| days                     | The number of days since unix epoch time.                 | number |
+| block_date               | The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format). | date |
 | chain_id                 | The standard chain id.                                    | number |
 | underlying_token_address | The contract address of the underlying token or deposited token. | string |
 | underlying_token_index   | The index of the underlying token in the smart contract, default 0. | number |

--- a/schemas/yield-aggregator/schema.json
+++ b/schemas/yield-aggregator/schema.json
@@ -65,16 +65,16 @@
       "label": "Position Snapshot",
       "tableName": "misc_depositors",
       "aggregation": "daily",
-      "uniqueKey": ["user_address", "pool_address", "days"],
+      "uniqueKey": ["user_address", "pool_address", "block_date"],
       "description": "Snapshot of the pool users.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "chain_id": {
           "description": "The standard chain id.",
@@ -114,16 +114,16 @@
       "label": "Pool Snapshot",
       "tableName": "misc_pool_metrics",
       "aggregation": "daily",
-      "uniqueKey": ["pool_address", "days"],
+      "uniqueKey": ["pool_address", "block_date"],
       "description": "TVL, fees, and incentives data at the pool level.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
           "type": "number"
         },
-        "days": {
-          "description": "The number of days since unix epoch time.",
-          "type": "number"
+        "block_date": {
+          "description": "The timestamp truncated (ie, 2023-03-04 in YYYY-MM-DD format).",
+          "type": "date"
         },
         "chain_id": {
           "description": "The standard chain id.",

--- a/schemas/yield-aggregator/schema.json
+++ b/schemas/yield-aggregator/schema.json
@@ -8,6 +8,7 @@
       "label": "Pools",
       "tableName": "misc_pools",
       "aggregation": "none",
+      "uniqueKey": ["pool_address"],
       "description": "List of pools in the protocol.",
       "properties": {
         "chain_id": {
@@ -64,10 +65,15 @@
       "label": "Position Snapshot",
       "tableName": "misc_depositors",
       "aggregation": "daily",
+      "uniqueKey": ["user_address", "pool_address", "days"],
       "description": "Snapshot of the pool users.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "chain_id": {
@@ -108,10 +114,15 @@
       "label": "Pool Snapshot",
       "tableName": "misc_pool_metrics",
       "aggregation": "daily",
+      "uniqueKey": ["pool_address", "days"],
       "description": "TVL, fees, and incentives data at the pool level.",
       "properties": {
         "timestamp": {
           "description": "The timestamp of the snapshot.",
+          "type": "number"
+        },
+        "days": {
+          "description": "The number of days since unix epoch time.",
           "type": "number"
         },
         "chain_id": {

--- a/schemas/yield-aggregator/schema.json
+++ b/schemas/yield-aggregator/schema.json
@@ -1,6 +1,7 @@
 {
   "schema": "Yield Aggregator (Leverage, Gambling, RWA, ALM, Liquidity/LP, index)",
   "description": "Standard table definitions for yield aggregator protocols (can include, Leverage, Gambling, RWA, ALM, Liquidity/LP, index).",
+  "protocolCategory": ["Automated Liquidity Manager", "Gambling", "Index", "Leverage", "Prediction Market", "RWA", "Yield", "Yield Aggregator"],
   "version": "1.0.0-alpha",
   "tables": [
     {


### PR DESCRIPTION
- Adding `uniqueKey` to each table. There can be multiple columns in the unique key. These identify the combination of columns.
- Added `protocolCategory` to each schema. This indicates the types of protocols that will use this schema.