### PR TITLE
Add spot price after swap to schema

### DIFF
--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -83,7 +83,7 @@ All trades across different types of DEXs.
 | output_token_symbol      | The symbol of the output token.                           | string |
 | output_token_address     | The contract address of the output token.                 | string |
 | output_token_amount      | The amount of the output token, decimal normalized.       | number |
-| spot_price_after_swap    | The spot price in the pool after the swap is complete.    | number |
+| spot_price_after_swap    | The spot price in the pool after the swap is complete. This is the price ratio a user would get if they made an infinitesimal swap immediately after this one.   | number |
 | swap_amount_usd          | (Optional) The amount of the swap in USD.                 | number |
 | fees_usd                 | (Optional) The fees paid by the user.                     | number |
 

--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -83,6 +83,7 @@ All trades across different types of DEXs.
 | output_token_symbol      | The symbol of the output token.                           | string |
 | output_token_address     | The contract address of the output token.                 | string |
 | output_token_amount      | The amount of the output token, decimal normalized.       | number |
+| spot_price_after_swap    | The spot price in the pool after the swap is complete.    | number |
 | swap_amount_usd          | (Optional) The amount of the swap in USD.                 | number |
 | fees_usd                 | (Optional) The fees paid by the user.                     | number |
 

--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -83,7 +83,7 @@ All trades across different types of DEXs.
 | output_token_symbol      | The symbol of the output token.                           | string |
 | output_token_address     | The contract address of the output token.                 | string |
 | output_token_amount      | The amount of the output token, decimal normalized.       | number |
-| spot_price_after_swap    | The spot price in the pool after the swap is complete. This is the price ratio a user would get if they made an infinitesimal swap immediately after this one.   | number |
+| spot_price_after_swap    | The spot price in the pool after the swap is complete. This is the price ratio a user would get if they made an infinitesimal swap immediately after this one. | number |
 | swap_amount_usd          | (Optional) The amount of the swap in USD.                 | number |
 | fees_usd                 | (Optional) The fees paid by the user.                     | number |
 

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -246,6 +246,10 @@
           "description": "The amount of the output token, decimal normalized.",
           "type": "number"
         },
+        "spot_price_after_swap": {
+          "description": "The spot price in the pool after the swap is complete.",
+          "type": "number"
+        },
         "swap_amount_usd": {
           "description": "(Optional) The amount of the swap in USD.",
           "type": "number"

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -247,7 +247,7 @@
           "type": "number"
         },
         "spot_price_after_swap": {
-          "description": "The spot price in the pool after the swap is complete.",
+          "description": "The spot price in the pool after the swap is complete. This is the price ratio a user would get if they made an infinitesimal swap immediately after this one.",
           "type": "number"
         },
         "swap_amount_usd": {


### PR DESCRIPTION
Proposal to add spot price after swap to the DEX swap schema. I want this so I can tell which liquidity is in range at any given time.

I don't know if this is feasible for all DEX types. Maybe we should have a separate table for v3 swaps that includes the tick after the swap (which I believe is standard in Uniswap v3 DEXs).