### PR TITLE
update v3 schema

### DIFF
--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -192,17 +192,16 @@ LP burn/mint events for V3 DEXs.
 | log_index                | The event log. For transactions that don't emit event, create arbitrary index starting from 0. | number |
 | transaction_hash         | The hash of the transaction.                              | string |
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
-| from_address             | The from address of the event (ie, the from field in a transfer). | string |
-| to_address               | The to address of the event (ie, the to field in a transfer). | string |
 | event_type               | The action type of the event (ie, mint, burn).            | string |
 | pool_address             | The contract address of the pool.                         | string |
-| tick_lower               | The lower tick.                                           | number |
-| tick_upper               | The upper tick.                                           | number |
-| tick_spacing             | The tick spacing.                                         | number |
+| tick_lower               | The lower tick of the liquidity position.                 | number |
+| tick_upper               | The upper tick of the liquidity position.                 | number |
+| current_tick             | The current tick of the pool.                             | number |
+| nft_token_id             | The token ID of the NFT that represents the liquidity position | number |
 | token0_address           | The contract address of token0.                           | string |
-| token0_amount            | The amount of token0.                                     | number |
+| token0_amount            | The amount of token0(raw token amount).                   | number |
 | token1_address           | The contract address of token1.                           | string |
-| token1_amount            | The amount of token1.                                     | number |
+| token1_amount            | The amount of token1(raw token amount).                   | number |
 | token_fees               | The amount of token fees.                                 | number |
 | amount_liquidity         | The amount of liquidity.                                  | number |
 

--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -196,7 +196,8 @@ LP burn/mint events for V3 DEXs.
 | pool_address             | The contract address of the pool.                         | string |
 | tick_lower               | The lower tick of the liquidity position.                 | number |
 | tick_upper               | The upper tick of the liquidity position.                 | number |
-| current_tick             | The current tick of the pool.                             | number |
+| current_tick             | The current tick of the liquidity pool.                   | number |
+| tick_spacing             | The tick spacing of the liquidity pool.                   | number |
 | nft_token_id             | The token ID of the NFT that represents the liquidity position | number |
 | token0_address           | The contract address of token0.                           | string |
 | token0_amount            | The amount of token0(raw token amount).                   | number |

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -568,14 +568,6 @@
           "description": "The address that initiates the transaction (ie, the transaction signer).",
           "type": "string"
         },
-        "from_address": {
-          "description": "The from address of the event (ie, the from field in a transfer).",
-          "type": "string"
-        },
-        "to_address": {
-          "description": "The to address of the event (ie, the to field in a transfer).",
-          "type": "string"
-        },
         "event_type": {
           "description": "The action type of the event (ie, mint, burn).",
           "type": "string"
@@ -585,15 +577,19 @@
           "type": "string"
         },
         "tick_lower": {
-          "description": "The lower tick.",
+          "description": "The lower tick of the liquidity position.",
           "type": "number"
         },
         "tick_upper": {
-          "description": "The upper tick.",
+          "description": "The upper tick of the liquidity position.",
           "type": "number"
         },
-        "tick_spacing": {
-          "description": "The tick spacing.",
+        "current_tick": {
+          "description": "The current tick of the pool.",
+          "type": "number"
+        },
+        "nft_token_id": {
+          "description": "The token ID of the NFT that represents the liquidity position",
           "type": "number"
         },
         "token0_address": {
@@ -601,7 +597,7 @@
           "type": "string"
         },
         "token0_amount": {
-          "description": "The amount of token0.",
+          "description": "The amount of token0(raw token amount).",
           "type": "number"
         },
         "token1_address": {
@@ -609,7 +605,7 @@
           "type": "string"
         },
         "token1_amount": {
-          "description": "The amount of token1.",
+          "description": "The amount of token1(raw token amount).",
           "type": "number"
         },
         "token_fees": {

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -585,7 +585,11 @@
           "type": "number"
         },
         "current_tick": {
-          "description": "The current tick of the pool.",
+          "description": "The current tick of the liquidity pool.",
+          "type": "number"
+        },
+        "tick_spacing": {
+          "description": "The tick spacing of the liquidity pool.",
           "type": "number"
         },
         "nft_token_id": {


### PR DESCRIPTION
making some changes to the v3 schema.

details regarding the changes made :
1) for `token0_amount` and `token1_amount` , does it make sense to get the raw amount for event level data here. there might be instances where new tokens are not added to Dune yet, so not possible to get normalized amount.

2) removed `from_address` and `to_address` : these are for transfer events , which belongs to the v3 transfer table.

3) added nft_token_id : this is required to track nft position

4) changed `tick_spacing` to `current_tick (tick of the LP pool at the specific event) . not sure if `tick_spacing` is required, will check with christian .

open questions : 
1) to standardize the naming convention for event_type [ lowercased / uppercased]

there will be more changes for v3 transfers , waiting for christian to work on the new data and update.