### PR TITLE
[Dex] update dex v3 transfer event schema

### DIFF
--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -221,17 +221,8 @@ LP transfer events for V3 DEXs.
 | transaction_from_address | The address that initiates the transaction (ie, the transaction signer). | string |
 | from_address             | The from address of the event (ie, the from field in a transfer). | string |
 | to_address               | The to address of the event (ie, the to field in a transfer). | string |
+| nft_token_id             | The token ID of the NFT transferred                       | number |
 | event_type               | The action type of the event (ie, transfer).              | string |
-| pool_address             | The contract address of the pool.                         | string |
-| tick_lower               | The lower tick.                                           | number |
-| tick_upper               | The upper tick.                                           | number |
-| tick_spacing             | The tick spacing.                                         | number |
-| token0_address           | The contract address of token0.                           | string |
-| token0_amount            | The amount of token0.                                     | number |
-| token1_address           | The contract address of token1.                           | string |
-| token1_amount            | The amount of token1.                                     | number |
-| token_fees               | The amount of token fees.                                 | number |
-| amount_liquidity         | The amount of liquidity.                                  | number |
 
 ### Incentive Claim Data
 

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -665,49 +665,13 @@
           "description": "The to address of the event (ie, the to field in a transfer).",
           "type": "string"
         },
+        "nft_token_id": {
+          "description": "The token ID of the NFT transferred",
+          "type": "number"
+        },
         "event_type": {
           "description": "The action type of the event (ie, transfer).",
           "type": "string"
-        },
-        "pool_address": {
-          "description": "The contract address of the pool.",
-          "type": "string"
-        },
-        "tick_lower": {
-          "description": "The lower tick.",
-          "type": "number"
-        },
-        "tick_upper": {
-          "description": "The upper tick.",
-          "type": "number"
-        },
-        "tick_spacing": {
-          "description": "The tick spacing.",
-          "type": "number"
-        },
-        "token0_address": {
-          "description": "The contract address of token0.",
-          "type": "string"
-        },
-        "token0_amount": {
-          "description": "The amount of token0.",
-          "type": "number"
-        },
-        "token1_address": {
-          "description": "The contract address of token1.",
-          "type": "string"
-        },
-        "token1_amount": {
-          "description": "The amount of token1.",
-          "type": "number"
-        },
-        "token_fees": {
-          "description": "The amount of token fees.",
-          "type": "number"
-        },
-        "amount_liquidity": {
-          "description": "The amount of liquidity.",
-          "type": "number"
         }
       }
     },


### PR DESCRIPTION
to track the nft token movement here to identify the owner. we can use the mint/burn events to calculate the fields (liquidity/upper and lower tick) 