### PR TITLE
Canonical schema update for lending and dex

### DIFF
--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -224,6 +224,24 @@ LP transfer events for V3 DEXs.
 | nft_token_id             | The token ID of the NFT transferred                       | string |
 | event_type               | The action type of the event (ie, transfer).              | string |
 
+### LP Position Snapshot (Staked In Farms)
+
+Snapshot of LP positions in farming contracts.
+
+| Property                | Description                                               | Type   |
+|-------------------------|-----------------------------------------------------------|--------|
+| timestamp                | The timestamp of the snapshot.                            | timestamp |
+| block_date               | The timestamp truncated (ie, YYYY-MM-DD format for daily snapshots and YYYY-MM-DD HH:00:00 for hourly snapshots). | date |
+| chain_id                 | The standard id of the chain.                             | int |
+| farm_address             | The contract address of the farming pool.                 | string |
+| pool_address             | The contract address of the liquidity pool.               | string |
+| user_address             | The address of the liquidity provider.                    | string |
+| token_index              | The token index based on the smart contract.              | bigint |
+| token_address            | The contract address of the token provided as liquidity.  | string |
+| token_symbol             | The symbol of the token.                                  | string |
+| token_amount             | The amount of the underlying liquidity position in the pool, decimal normalized (ie, the amount of USDC provided by the LPer in a USDC/WETH pool). | double |
+| token_amount_usd         | The amount of the token in USD.                           | double |
+
 ### Liquidity Transaction Events (General)
 
 Event data capturing activities related to liquidity transactions, including deposits and withdrawals

--- a/schemas/dex/SCHEMA.md
+++ b/schemas/dex/SCHEMA.md
@@ -224,6 +224,26 @@ LP transfer events for V3 DEXs.
 | nft_token_id             | The token ID of the NFT transferred                       | string |
 | event_type               | The action type of the event (ie, transfer).              | string |
 
+### Liquidity Transaction Events (General)
+
+Event data capturing activities related to liquidity transactions, including deposits and withdrawals
+
+| Property                | Description                                               | Type   |
+|-------------------------|-----------------------------------------------------------|--------|
+| timestamp                | The timestamp of the transaction.                         | timestamp |
+| chain_id                 | The standard id of the chain.                             | int |
+| block_number             | The block number of the transaction.                      | bigint |
+| log_index                | The event log. For transactions that don't emit events, create arbitrary index starting from 0. | bigint |
+| transaction_hash         | The hash of the transaction.                              | string |
+| user_address             | The address that initiates the transaction (i.e., the transaction signer). | string |
+| taker_address            | The address that receives the output of the event (i.e., the account that receives LP receipt tokens). | string |
+| pool_address             | The contract address of the pool.                         | string |
+| token_address            | The address of the underlying token that was interacted with. | bigint |
+| token_index              | The index in the pool smart contract that this token appears at, default 0 (ie, one entry per token in a pool). | bigint |
+| token_amount             | The token amount of the underlying asset being added/removed from the pool , decimal normalized | double |
+| token_amount_usd         | The amount of the token in USD.                           | double |
+| event_type               | The type of event, corresponds to the action taken by the user (e.g., deposit, withdrawal). | double |
+
 ### Incentive Claim Data
 
 Transactional data on user level incentives claimed data.

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -715,6 +715,67 @@
       }
     },
     {
+      "label": "Liquidity Transaction Events (General)",
+      "tableName": "liquidity_transaction_events",
+      "description": "Event data capturing activities related to liquidity transactions, including deposits and withdrawals",
+      "aggregation": "none",
+      "uniqueKey": ["transaction_hash","token_index","log_index"],
+      "properties": {
+        "timestamp": {
+          "description": "The timestamp of the transaction.",
+          "type": "timestamp"
+        },
+        "chain_id": {
+          "description": "The standard id of the chain.",
+          "type": "int"
+        },
+        "block_number": {
+          "description": "The block number of the transaction.",
+          "type": "bigint"
+        },
+        "log_index": {
+          "description": "The event log. For transactions that don't emit events, create arbitrary index starting from 0.",
+          "type": "bigint"
+        },
+        "transaction_hash": {
+          "description": "The hash of the transaction.",
+          "type": "string"
+        },
+        "user_address": {
+          "description": "The address that initiates the transaction (i.e., the transaction signer).",
+          "type": "string"
+        },
+        "taker_address": {
+          "description": "The address that receives the output of the event (i.e., the account that receives LP receipt tokens).",
+          "type": "string"
+        },
+        "pool_address": {
+          "description": "The contract address of the pool.",
+          "type": "string"
+        },
+        "token_address": {
+          "description": "The address of the underlying token that was interacted with.",
+          "type": "bigint"
+        },
+        "token_index": {
+          "description": "The index in the pool smart contract that this token appears at, default 0 (ie, one entry per token in a pool).",
+          "type": "bigint"
+        },
+        "token_amount": {
+          "description": "The token amount of the underlying asset being added/removed from the pool , decimal normalized",
+          "type": "double"
+        },
+        "token_amount_usd": {
+          "description": "The amount of the token in USD.",
+          "type": "double"
+        },
+        "event_type": {
+          "description": "The type of event, corresponds to the action taken by the user (e.g., deposit, withdrawal).",
+          "type": "double"
+        }
+      }
+    },    
+    {
       "label": "Incentive Claim Data",
       "tableName": "dex_incentive_claim",
       "aggregation": "transaction",

--- a/schemas/dex/schema.json
+++ b/schemas/dex/schema.json
@@ -715,6 +715,64 @@
       }
     },
     {
+      "label": "LP Position Snapshot (Staked In Farms)",
+      "tableName": "farm_lp_position_snapshot",
+      "aggregation": "daily",
+      "uniqueKey": [
+        "user_address",
+        "pool_address",
+        "token_index",
+        "block_date"
+      ],
+      "description": "Snapshot of LP positions in farming contracts.",
+      "properties": {
+        "timestamp": {
+          "description": "The timestamp of the snapshot.",
+          "type": "timestamp"
+        },
+        "block_date": {
+          "description": "The timestamp truncated (ie, YYYY-MM-DD format for daily snapshots and YYYY-MM-DD HH:00:00 for hourly snapshots).",
+          "type": "date"
+        },
+        "chain_id": {
+          "description": "The standard id of the chain.",
+          "type": "int"
+        },
+        "farm_address": {
+          "description": "The contract address of the farming pool.",
+          "type": "string"
+        },
+        "pool_address": {
+          "description": "The contract address of the liquidity pool.",
+          "type": "string"
+        },
+        "user_address": {
+          "description": "The address of the liquidity provider.",
+          "type": "string"
+        },
+        "token_index": {
+          "description": "The token index based on the smart contract.",
+          "type": "bigint"
+        },
+        "token_address": {
+          "description": "The contract address of the token provided as liquidity.",
+          "type": "string"
+        },
+        "token_symbol": {
+          "description": "The symbol of the token.",
+          "type": "string"
+        },
+        "token_amount": {
+          "description": "The amount of the underlying liquidity position in the pool, decimal normalized (ie, the amount of USDC provided by the LPer in a USDC/WETH pool).",
+          "type": "double"
+        },
+        "token_amount_usd": {
+          "description": "The amount of the token in USD.",
+          "type": "double"
+        }
+      }
+    },
+    {
       "label": "Liquidity Transaction Events (General)",
       "tableName": "liquidity_transaction_events",
       "description": "Event data capturing activities related to liquidity transactions, including deposits and withdrawals",

--- a/schemas/lending/SCHEMA.md
+++ b/schemas/lending/SCHEMA.md
@@ -18,6 +18,7 @@ List of pools in the lending protocol.
 | receipt_token_address    | The contract address of the receipt token.                | string |
 | receipt_token_symbol     | The symbol of the receipt token.                          | string |
 | pool_address             | The contract address of the pool.                         | string |
+| market_address           | The contract responsible for configuring the market parameters (e.g., Comptroller in Compound or Pool Configurator in Aave) | string |
 | pool_type                | The type of the pool (collateral_only, isolated, supply_pool, cdp). | string |
 
 ### Position Snapshot

--- a/schemas/lending/schema.json
+++ b/schemas/lending/schema.json
@@ -48,6 +48,10 @@
           "description": "The contract address of the pool.",
           "type": "string"
         },
+        "market_address": {
+          "description": "The contract responsible for configuring the market parameters (e.g., Comptroller in Compound or Pool Configurator in Aave)",
+          "type": "string"
+        },
         "pool_type": {
           "description": "The type of the pool (collateral_only, isolated, supply_pool, cdp).",
           "type": "string"


### PR DESCRIPTION
Lending - there will be protocols that have several isolated markets. The current canonical schema will not be able to identify which market the pool belongs to. Without this, we will not be able to calculate non-recursive borrowing accurately.

DEX - currently liquidity provision events are mainly for v2/v3 forks. created a new schema to cover those protocols that do not fit in the current schema / have > 2 tokens . also included a new schema to identify positions that are in farming contracts